### PR TITLE
Use template name for blog path

### DIFF
--- a/layout/item.html
+++ b/layout/item.html
@@ -2,7 +2,7 @@
 <h2><a href="{{ base_path }}/{{ blog }}/{{ slug }}/">{{ title }}</a></h2>
 <p class="meta">Published on {{ date }} by <b>{{ author }}</b></p>
 <p class="summary">
-{{ summary }}&nbsp;<a class="more" href="{{ base_path }}/blog/{{ slug }}/">...</a>
+{{ summary }}&nbsp;<a class="more" href="{{ base_path }}/{{ blog }}/{{ slug }}/">...</a>
 </p>
 <div>
 <a class="more" href="{{ base_path }}/{{ blog }}/{{ slug }}/">Read More</a>


### PR DESCRIPTION
One of the paths was hardcoded in `index.html`