### PR TITLE
Add cleaner python2/3 make serve command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,14 @@
+PYTHON3_AVAILABLE := $(shell python3 --version 2>&1)
+
 site:
 	./makesite.py
 
 serve: site
-	cd _site && python -m SimpleHTTPServer 2> /dev/null || python3 -m http.server
+ifeq ('$(PYTHON3_AVAILABLE)','')
+	cd _site && python -m SimpleHTTPServer
+else
+	cd _site && python3 -m http.server
+endif
 
 venv2:
 	virtualenv ~/.venv/makesite


### PR DESCRIPTION
Stops the need to Ctrl-C twice in the event where you have both python versions on your system