### PR TITLE
Allow any renderable page to live in content.

### DIFF
--- a/makesite.py
+++ b/makesite.py
@@ -200,7 +200,7 @@ def main():
     # Create site pages.
     make_pages('content/_index.html', '_site/index.html',
                page_layout, **params)
-    make_pages('content/[!_]*.html', '_site/{{ slug }}/index.html',
+    make_pages('content/[!_]*.*', '_site/{{ slug }}/index.html',
                page_layout, **params)
 
     # Create blogs.


### PR DESCRIPTION
As things are only .html files can live in the content directory.

This simple change should allow any pages renderable by read_content()
to live here.

This is useful if you want to have .md pages.